### PR TITLE
Various changes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ LOGI.off()
 
 # Change input
 
-Changes the input and applies the input effect. If not input effect is selected, the device's factory defaults will be used
+Changes the input and applies the input effect. If no input effect is selected, the device's factory defaults will be used.
 ```C++
 LOGI.input(input, effect)
 ```
@@ -174,11 +174,11 @@ while(LOGI.request(VERSION) == 0)
 
 Serial.println("Z906 Version : " + (String) LOGI.request(VERSION));
 
-// Power ON PWM Generator
-LOGI.cmd(PWM_ON);
+// Power ON the amplifier
+LOGI.on();
 
 // Select RCA 2.0 Input
-LOGI.cmd(SELECT_INPUT_2);
+LOGI.input(SELECT_INPUT_2);
 
 // Disable Mute
 LOGI.cmd(MUTE_OFF);

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ LOGI.cmd(MAIN_LEVEL, 15)  // Set Main Level to 15
 
 ```C++
 LOGI.request(MAIN_LEVEL)    // return current Main Level
-LOGI.request(READ_LEVEL)    // return current Read Level
+LOGI.request(REAR_LEVEL)    // return current Rear Level
 LOGI.request(CENTER_LEVEL)  // return current Center Level
 LOGI.request(SUB_LEVEL)     // return current Subwoofer Level
 
@@ -123,7 +123,7 @@ LOGI.request(VERSION)       // return firmware version
 |argument a|argument b|description|
 |---|---|---|
 |MAIN_LEVEL|0-255|Set Main Level to argument b value|
-|READ_LEVEL|0-255|Set Read Level to argument b value|
+|REAR_LEVEL|0-255|Set Rear Level to argument b value|
 |CENTER_LEVEL|0-255|Set Center Level to argument b value|
 |SUB_LEVEL|0-255|Set Sub Level to argument b value|
 
@@ -136,6 +136,21 @@ Use the **EEPROM_SAVE** function with caution. Each EEPROM has a limited number 
 return the value of main temperature sensor.
 ```C++
 LOGI.main_sensor()
+```
+
+# Turn the amplifyer  on or off
+
+Turns the amplifyer on or off. When turning off, the amplifyer will also store the current state of the unit in EEPROM. Note, that the amplifyer still draws a certain amount of power and will only fully turn off, if you also open the connection between pin15 and GND on the DSUB connector.
+```C++
+LOGI.on()
+LOGI.off()
+```
+
+# Change input
+
+Changes the input and applies the input effect. If not input effect is selected, the device's factory defaults will be used
+```C++
+LOGI.input(input, effect)
 ```
 
 # Basic Example

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ return the value of main temperature sensor.
 LOGI.main_sensor()
 ```
 
-# Turn the amplifyer  on or off
+# Turn the amplifier  on or off
 
-Turns the amplifyer on or off. When turning off, the amplifyer will also store the current state of the unit in EEPROM. Note, that the amplifyer still draws a certain amount of power and will only fully turn off, if you also open the connection between pin15 and GND on the DSUB connector.
+Turns the amplifier on or off. When turning off, the amplifier will also store the current state of the unit in EEPROM. Note, that the amplifier still draws a certain amount of power and will only fully turn off, if you also open the connection between pin15 and GND on the DSUB connector.
 ```C++
 LOGI.on()
 LOGI.off()

--- a/examples/basic/basic.ino
+++ b/examples/basic/basic.ino
@@ -27,11 +27,11 @@ while(LOGI.request(VERSION) == 0)
 
 Serial.println("Z906 Version : " + (String) LOGI.request(VERSION));
 
-// Power ON PWM Generator
-LOGI.cmd(PWM_ON);
+// Power ON amplifier
+LOGI.on();
 
 // Select RCA 2.0 Input
-LOGI.cmd(SELECT_INPUT_2);
+LOGI.input(SELECT_INPUT_2);
 
 // Disable Mute
 LOGI.cmd(MUTE_OFF);

--- a/src/Z906.cpp
+++ b/src/Z906.cpp
@@ -6,51 +6,108 @@ Z906::Z906(HardwareSerial &serial) {
 }
 
 // Longitudinal Redundancy Check {-1,-1}
-
-uint8_t Z906::LRC(uint8_t* pData, uint8_t length){
+uint8_t Z906::LRC(uint8_t* pData, size_t length){
 
 	uint8_t LRC = 0;
 
-    for (int i = 1; i < length-1; i++) LRC -= pData[i];
+    for(size_t i = 1; i < length-1; i++) LRC -= pData[i];
 
 	return LRC;
+
 }
 
+void Z906::on(){
+    write(PWM_ON);
+}
+
+void Z906::off(){
+    write(PWM_OFF);
+
+    uint8_t cmd[] = { RESET_PWR_UP_TIME, 0x37, EEPROM_SAVE };
+    write(cmd, sizeof(cmd));
+    flush();    // Discard ACK
+}
+
+void Z906::input(uint8_t input, uint8_t effect){
+    // If no effect is select, use default (same as console default)
+    if(effect = 0xFF){
+        if(input == SELECT_INPUT_2 || input == SELECT_INPUT_AUX){
+            effect = SELECT_EFFECT_3D;
+        } else {
+            effect = SELECT_EFFECT_NO;
+        }
+    }
+
+    uint8_t cmd[] = { MUTE_ON, input, effect, MUTE_OFF };
+    write(cmd, sizeof(cmd));
+    flush();    // Discard ACK
+}
+
+void Z906::flush(){
+    delay(SERIAL_DEADTIME);         //Avoid UART TX collisions
+    dev_serial->flush(false);       //Clear RX buffer
+}
+
+void Z906::write(uint8_t cmd){
+	flush();
+	dev_serial->write(cmd);
+	dev_serial->flush();            //Flush TX buffer to device
+}
+
+void Z906::write(uint8_t* pCmd, size_t cmd_len){
+    flush();
+
+	for(size_t i = 0; i < cmd_len; i++)
+	    dev_serial->write(pCmd[i]);
+
+    dev_serial->flush();            //Flush TX buffer to device
+}
 
 int Z906::update(){
-	
-	dev_serial->write(GET_STATUS);
-	
+
+	write(GET_STATUS);
+
 	unsigned long currentMillis = millis();
 	
-	while(dev_serial->available() < STATUS_TOTAL_LENGTH)
+    // Determine payload size and total required buffer size
+	while(dev_serial->available() < STATUS_LENGTH + 1)
+	if (millis() - currentMillis > SERIAL_TIME_OUT) return 0;
+    
+	for(int i = 0; i <= STATUS_LENGTH; i++) status[i] = dev_serial->read();
+
+    size_t payload_len = status[STATUS_LENGTH];     //Size of the payload
+    status_len = payload_len + 4;                   //Size of full status buffer in RAM
+
+	while(dev_serial->available() < payload_len + 1)
 	if (millis() - currentMillis > SERIAL_TIME_OUT) return 0;
 
-	for(int i = 0; i < STATUS_TOTAL_LENGTH; i++) status[i] = dev_serial->read();
-	
+    //Read payload + checksum
+    for(int i = 0; i <= payload_len; i++) status[i + STATUS_LENGTH + 1] = dev_serial->read();
+    STATUS_CHECKSUM = status_len - 1;
+
     if (status[STATUS_STX] != EXP_STX) return 0;
     if (status[STATUS_MODEL] != EXP_MODEL_STATUS) return 0;
-	if (status[STATUS_CHECKSUM] == LRC(status, STATUS_TOTAL_LENGTH)) return 1;
+	if (status[STATUS_CHECKSUM] == LRC(status, status_len)) return 1;
 	
 	return 0;
 	
 }
 
 int Z906::request(uint8_t cmd){
-	
-	if(update())
-	{
-	if(cmd == VERSION) return status[STATUS_VER_C] + 10 * status[STATUS_VER_B] + 100 * status[STATUS_VER_A];
-	if(cmd == CURRENT_INPUT) return status[STATUS_CURRENT_INPUT] + 1;
-	
-	return status[cmd];
+    
+	if(update()){
+        if(cmd == VERSION) return status[STATUS_VER_C] + 10 * status[STATUS_VER_B] + 100 * status[STATUS_VER_A];
+        if(cmd == CURRENT_INPUT) return status[STATUS_CURRENT_INPUT] + 1;
+        if(cmd == MAIN_LEVEL || cmd == REAR_LEVEL || cmd == CENTER_LEVEL || cmd == SUB_LEVEL) return (uint8_t) (((uint16_t) status[cmd])*255/MAX_VOL);
+
+        return status[cmd];
 	}
 	return 0;
 }
 
 int Z906::cmd(uint8_t cmd){
-	
-	dev_serial->write(cmd);
+
+    write(cmd);
 
 	unsigned long currentMillis = millis();
 	
@@ -61,30 +118,26 @@ int Z906::cmd(uint8_t cmd){
 }
 
 int Z906::cmd(uint8_t cmd_a, uint8_t cmd_b){
-	
+
 	update();
 	
+    //Normalize volume to 0...255
+    if(cmd_a == MAIN_LEVEL || cmd_a == REAR_LEVEL || cmd_a == CENTER_LEVEL || cmd_a == SUB_LEVEL)
+        cmd_b = (uint8_t) (((uint16_t) cmd_b)*MAX_VOL/255);
+
 	status[cmd_a] = cmd_b;
+	status[STATUS_CHECKSUM] = LRC(status, status_len);
 	
-	status[STATUS_CHECKSUM] = LRC(status, STATUS_TOTAL_LENGTH);
-	
-	for(int i = 0; i <STATUS_TOTAL_LENGTH; i++)
-	dev_serial->write(status[i]);
+    write(status, status_len);
 
-	unsigned long currentMillis = millis();
-	
-	while(dev_serial->available() < ACK_TOTAL_LENGTH)
-	if (millis() - currentMillis > SERIAL_TIME_OUT) return 0;
-
-	for(int i = 0; i < ACK_TOTAL_LENGTH; i++) dev_serial->read();
-
+    flush(); // Discard ACK message
 }
 
 void Z906::print_status(){
-	
+
 	update();
 	
-	for(int i = 0; i <STATUS_TOTAL_LENGTH; i++)
+	for(int i = 0; i < status_len; i++)
 	{
 		Serial.print(status[i],HEX);
 		Serial.print(" ");
@@ -93,8 +146,8 @@ void Z906::print_status(){
 }
 
 uint8_t Z906::main_sensor(){
-	
-	dev_serial->write(GET_TEMP);
+
+	write(GET_TEMP);
 	
 	unsigned long currentMillis = millis();
 	

--- a/src/Z906.h
+++ b/src/Z906.h
@@ -1,81 +1,85 @@
+#ifndef Z906_H
+#define Z906_H
+
 #include "Arduino.h"
 
 // Serial Settings
 
-#define BAUD_RATE     		57600
-#define SERIAL_CONFIG		SERIAL_8O1
-#define	SERIAL_TIME_OUT		1000
+#define BAUD_RATE           57600
+#define SERIAL_CONFIG       SERIAL_8O1
+#define	SERIAL_TIME_OUT     1000
+#define SERIAL_DEADTIME     5
 
-#define	STATUS_TOTAL_LENGTH	0x17
-#define	ACK_TOTAL_LENGTH	0x05
-#define	TEMP_TOTAL_LENGTH	0x0A
+#define	STATUS_BUFFER_SIZE  0x20
+#define	ACK_TOTAL_LENGTH    0x05
+#define	TEMP_TOTAL_LENGTH   0x0A
 
 // Single Commands
 
-#define SELECT_INPUT_1		0x02
-#define SELECT_INPUT_2		0x05
-#define SELECT_INPUT_3		0x03
-#define SELECT_INPUT_4		0x04
-#define SELECT_INPUT_5		0x06
-#define SELECT_INPUT_AUX	0x07
+#define SELECT_INPUT_1      0x02
+#define SELECT_INPUT_2      0x05
+#define SELECT_INPUT_3      0x03
+#define SELECT_INPUT_4      0x04
+#define SELECT_INPUT_5      0x06
+#define SELECT_INPUT_AUX    0x07
 
-#define LEVEL_MAIN_UP     0x08
-#define LEVEL_MAIN_DOWN   0x09
-#define LEVEL_SUB_UP      0x0A
-#define LEVEL_SUB_DOWN    0x0B
-#define LEVEL_CENTER_UP   0x0C
-#define LEVEL_CENTER_DOWN 0x0D
-#define LEVEL_REAR_UP     0x0E
-#define LEVEL_REAR_DOWN   0x0F
+#define LEVEL_MAIN_UP       0x08
+#define LEVEL_MAIN_DOWN     0x09
+#define LEVEL_SUB_UP        0x0A
+#define LEVEL_SUB_DOWN      0x0B
+#define LEVEL_CENTER_UP     0x0C
+#define LEVEL_CENTER_DOWN   0x0D
+#define LEVEL_REAR_UP       0x0E
+#define LEVEL_REAR_DOWN     0x0F
 
-#define	PWM_OFF           0x10
-#define	PWM_ON            0x11
+#define	PWM_OFF             0x10
+#define	PWM_ON              0x11
 
-#define SELECT_EFFECT_3D  0x14			
-#define SELECT_EFFECT_41  0x15			
-#define SELECT_EFFECT_21  0x16			
-#define SELECT_EFFECT_NO  0x35			
+#define SELECT_EFFECT_3D    0x14			
+#define SELECT_EFFECT_41    0x15			
+#define SELECT_EFFECT_21    0x16			
+#define SELECT_EFFECT_NO    0x35			
 
-#define	EEPROM_SAVE       0x36
+#define	EEPROM_SAVE         0x36
 
-#define	MUTE_ON           0x38
-#define	MUTE_OFF          0x39
+#define	MUTE_ON             0x38
+#define	MUTE_OFF            0x39
 
-#define BLOCK_INPUTS      0x22
-#define RESET_PWR_UP_TIME 0x30
-#define NO_BLOCK_INPUTS   0x33
+#define BLOCK_INPUTS        0x22
+#define RESET_PWR_UP_TIME   0x30
+#define NO_BLOCK_INPUTS     0x33
 
 // Double commmands
 
-#define MAIN_LEVEL        0x03
-#define READ_LEVEL        0x04
-#define CENTER_LEVEL      0x05
-#define SUB_LEVEL         0x06
+#define MAIN_LEVEL          0x03
+#define REAR_LEVEL          0x04
+#define CENTER_LEVEL        0x05
+#define SUB_LEVEL           0x06
 
 // Requests
 
-#define VERSION           0xF0
-#define CURRENT_INPUT     0xF1
-#define GET_INPUT_GAIN    0x2F
-#define GET_TEMP          0x25
-#define GET_PWR_UP_TIME   0x31
-#define GET_STATUS        0x34
+#define VERSION             0xF0
+#define CURRENT_INPUT       0xF1
+#define GET_INPUT_GAIN      0x2F
+#define GET_TEMP            0x25
+#define GET_PWR_UP_TIME     0x31
+#define GET_STATUS          0x34
 
 // MASK
 
-#define EFFECT_3D         0x00			
-#define EFFECT_21         0x01			
-#define EFFECT_41         0x02			
-#define EFFECT_NO         0x03			
+#define EFFECT_3D           0x00			
+#define EFFECT_21           0x01			
+#define EFFECT_41           0x02			
+#define EFFECT_NO           0x03			
 
-#define SPK_NONE          0x00			
-#define SPK_ALL           0xFF
-#define SPK_FR            0x01
-#define SPK_FL            0x10
-#define SPK_RR            0x02
-#define SPK_RL            0x08
-#define SPK_CENTER        0x04
-#define	SPK_SUB           0x20
+#define SPK_NONE            0x00			
+#define SPK_ALL             0xFF
+#define SPK_FR              0x01
+#define SPK_FL              0x10
+#define SPK_RR              0x02
+#define SPK_RL              0x08
+#define SPK_CENTER          0x04
+#define	SPK_SUB             0x20
 
 class Z906
 {
@@ -90,6 +94,10 @@ void 	print_status();
 
 uint8_t main_sensor();
 
+void    on();
+void    off();
+void    input(uint8_t, uint8_t = 0xFF);
+
 private:
 
 const uint8_t EXP_STX               = 0xAA;
@@ -100,7 +108,7 @@ const uint8_t STATUS_STX            = 0x00;
 const uint8_t STATUS_MODEL          = 0x01;
 const uint8_t STATUS_LENGTH         = 0x02;
 const uint8_t STATUS_MAIN_LEVEL     = 0x03;
-const uint8_t STATUS_READ_LEVEL     = 0x04;
+const uint8_t STATUS_REAR_LEVEL     = 0x04;
 const uint8_t STATUS_CENTER_LEVEL   = 0x05;
 const uint8_t STATUS_SUB_LEVEL      = 0x06;
 const uint8_t STATUS_CURRENT_INPUT  = 0x07;
@@ -118,13 +126,19 @@ const uint8_t STATUS_VER_B          = 0x12;
 const uint8_t STATUS_VER_C          = 0x13;
 const uint8_t STATUS_STBY           = 0x14;
 const uint8_t STATUS_AUTO_STBY      = 0x15;
-const uint8_t STATUS_CHECKSUM       = 0x16;
+uint8_t       STATUS_CHECKSUM       = 0;    // Will be dynamically derived in update()
+
+const uint8_t MAX_VOL               = 43;   // Maximum volume can only be 43
 
 HardwareSerial* dev_serial;
 
+void    write(uint8_t);
+void    write(uint8_t*, size_t);
+void    flush();
 int 	update();
-uint8_t LRC(uint8_t*, uint8_t);
-uint8_t status[STATUS_TOTAL_LENGTH];
+uint8_t LRC(uint8_t*, size_t);
+uint8_t status[STATUS_BUFFER_SIZE];
+size_t  status_len = 0; //Size of the full message in the status buffer (incl. control words and checksum)
 };
 
-
+#endif // Z906_H


### PR DESCRIPTION
This PR fixes several issues I observed with my unit. 
My recently acquired Z906 device has a status message, that was one byte longer. This introduced several problems:
1: The not-read byte(s) remained on the serial Rx buffer and then was read with the next Serial.read() event. This resulted in an invalid status message.
2: Since the last status byte (checksum) was not read, Z906:update() failed when validating the message.

1 + 2 have been fixed by reading the status message length from the actual status message itself (byte @ 0x02).

3: Writing cmds to the amplifier in fast succession occasionally made the amplifier getting "stuck" with its reply. This is fixed by adding a 5ms SERIAL_DEADTIME here and there to give the amplifier enough time to reply.
4: The readme states valid volume ranges from 0...255. While technically the byte sent to the device can have a value in that range, the device only properly adjusts the volume when the value is between 0...43. The library has been adjusted such, that every command written to or read from will be rescaled linearily 0...255 -> 0...43 and vice versa.
5: Interface: Added on(), off() and input(). Renamed READ_VOLUME to REAR_VOLUME (typo)